### PR TITLE
Update Bricks.cpp

### DIFF
--- a/src/vsgPoints/Bricks.cpp
+++ b/src/vsgPoints/Bricks.cpp
@@ -29,7 +29,7 @@ void Bricks::add(const vsg::dvec3& v, const vsg::ubvec4& c)
 
     auto divide_round = [](int64_t value, int64_t divisor) -> int64_t {
         if (value < 0)
-            return -1 - (-value / divisor);
+            return -1 - -(value + 1) / divisor;
         else
             return value / divisor;
     };

--- a/src/vsgPoints/Bricks.cpp
+++ b/src/vsgPoints/Bricks.cpp
@@ -29,7 +29,7 @@ void Bricks::add(const vsg::dvec3& v, const vsg::ubvec4& c)
 
     auto divide_round = [](int64_t value, int64_t divisor) -> int64_t {
         if (value < 0)
-            return -1 - -(value + 1) / divisor;
+            return -1 + (value + 1) / divisor;
         else
             return value / divisor;
     };


### PR DESCRIPTION
Fixes a bug in "divide_round" which resulted in incorrect keys being calculated for negative values falling on divisor boundaries. 

```
    auto divide_round = [](int64_t value, int64_t divisor) -> int64_t {
        if (value < 0)
            return -1 - (-value / divisor);
        else
            return value / divisor;
    };
```

For example if value is -256 and divisor is 256, this would return a key of -2, when it should be the first entry in key -1

This resulted in artifacts on pointclouds with negative coordinates.

proposed fix is:

```
        if (value < 0)
            return -1 + (value + 1) / divisor;

```


