### PR TITLE
Point selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,17 @@ vsg_setup_dir_vars()
 vsg_add_target_clang_format(
     FILES
         include/vsgPoints/*.h
+        include/vsgPoints/utils/*.h
         src/vsgPoints/*.cpp
+        src/vsgPoints/utils/*.cpp
 )
 vsg_add_target_clobber()
 vsg_add_target_cppcheck(
     FILES
         ${CMAKE_SOURCE_DIR}/src/vsgPoints/*.cpp
         ${CMAKE_SOURCE_DIR}/include/vsgPoints/*.h
+        ${CMAKE_SOURCE_DIR}/include/vsgPoints/*.h
+        ${CMAKE_SOURCE_DIR}/include/vsgPoints/utils/*.h
     )
 vsg_add_target_docs(
     FILES
@@ -51,8 +55,14 @@ if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
 
 endif()
 
+# enable folders for MSVC
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 # source directories for vsgPoints library
 add_subdirectory(src)
+
+set(CMAKE_FOLDER applications)
 add_subdirectory(applications)
+unset(CMAKE_FOLDER)
 
 vsg_add_feature_summary()

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(vsgpoints_example)
+add_subdirectory(pointselection)

--- a/applications/pointselection/CMakeLists.txt
+++ b/applications/pointselection/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(SOURCES
+    pointselection.cpp
+)
+
+add_executable(pointselection ${SOURCES})
+
+target_link_libraries(pointselection vsg::vsg vsgPoints::vsgPoints)
+
+if (vsgXchange_FOUND)
+    target_compile_definitions(pointselection PRIVATE vsgXchange_FOUND)
+    target_link_libraries(pointselection vsgXchange::vsgXchange)
+endif()
+
+install(TARGETS pointselection RUNTIME DESTINATION bin)

--- a/applications/pointselection/pointselection.cpp
+++ b/applications/pointselection/pointselection.cpp
@@ -1,0 +1,579 @@
+#include <vsg/all.h>
+
+#ifdef vsgXchange_FOUND
+#    include <vsgXchange/all.h>
+#endif
+
+#include <vsgPoints/BIN.h>
+#include <vsgPoints/AsciiPoints.h>
+#include <vsgPoints/create.h>
+#include <vsgPoints/utils/PointsPolytopeIntersector.h>
+#include <vsgPoints/utils/PolygonIntersector.h>
+
+#include <iomanip>
+#include <iostream>
+#include <random>
+
+#define MAX_POLYGON_VERTICES 1000
+
+vsg::ref_ptr<vsg::StateGroup> create_wirefame_stateGroup()
+{
+    std::string VERT{R"(
+    #version 450
+    layout(push_constant) uniform PushConstants { mat4 projection; mat4 modelView; };
+    layout(location = 0) in vec3 vertex;
+    out gl_PerVertex { vec4 gl_Position; };
+    void main() { gl_Position = (projection * modelView) * vec4(vertex, 1.0); }
+    )"};
+
+    std::string FRAG{R"(
+    #version 450
+    layout(location = 0) out vec4 color;
+    void main() { color = vec4(1, 1, 1, 1); }
+    )"};
+
+    auto vertexShader = vsg::ShaderStage::create(VK_SHADER_STAGE_VERTEX_BIT, "main", VERT);
+    auto fragmentShader = vsg::ShaderStage::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", FRAG);
+    auto shaderSet = vsg::ShaderSet::create(vsg::ShaderStages{vertexShader, fragmentShader});
+    shaderSet->addPushConstantRange("pc", "", VK_SHADER_STAGE_VERTEX_BIT, 0, 128);
+    shaderSet->addAttributeBinding("vertex", "", 0, VK_FORMAT_R32G32B32_SFLOAT, vsg::vec3Array::create(1));
+
+    auto stateGroup = vsg::StateGroup::create();
+    auto gpConf = vsg::GraphicsPipelineConfigurator::create(shaderSet);
+
+    gpConf->enableArray("vertex", VK_VERTEX_INPUT_RATE_VERTEX, sizeof(vsg::vec3), VK_FORMAT_R32G32B32_SFLOAT);
+
+    struct SetPipelineStates : public vsg::Visitor
+    {
+        void apply(vsg::Object& object) { object.traverse(*this); }
+        void apply(vsg::RasterizationState& rs)
+        {
+            rs.lineWidth = 1.0f;
+            rs.cullMode = VK_CULL_MODE_NONE;
+        }
+        void apply(vsg::InputAssemblyState& ias)
+        {
+            ias.topology = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
+        }
+    } sps;
+
+    gpConf->accept(sps);
+    gpConf->init();
+    gpConf->copyTo(stateGroup);
+    return stateGroup;
+}
+
+
+class ResizeHandler : public vsg::Inherit<vsg::Visitor, ResizeHandler>
+{
+public:
+    vsg::ref_ptr<vsg::Camera> camera;
+
+    ResizeHandler(vsg::ref_ptr<vsg::Camera> in_camera)
+        : camera(in_camera) {}
+
+    void apply(vsg::ConfigureWindowEvent& configWindowEvent) override
+    {
+        auto extents = configWindowEvent.window.ref_ptr()->extent2D();
+        auto projection = vsg::Orthographic::create(0, extents.width, extents.height, 0, 100.0, 0.0);
+        auto lookAt = vsg::LookAt::create(vsg::dvec3(0.0, 0.0, 80.0), vsg::dvec3(0.0, 0.0, 0.0), vsg::dvec3(0.0, 1.0, 0.0));
+        camera->projectionMatrix = projection;
+        camera->viewMatrix = lookAt;
+    }
+};
+
+
+class SelectionHandler : public vsg::Inherit<vsg::Visitor, SelectionHandler>
+{
+public:
+
+    enum SelectionMode
+    {
+        NONE,
+        POLYGON,
+        SQUARE
+    };
+
+    vsg::ref_ptr<vsg::Camera> camera;
+    vsg::ref_ptr<vsg::Group> scenegraph;
+    vsg::ref_ptr<vsg::Switch> polygon_switch;
+    vsg::ref_ptr<vsg::Switch> square_switch;
+    vsg::ref_ptr<vsg::vec3Array> poly_vertices;
+    vsg::ref_ptr<vsg::VertexDraw> poly_vertexDraw;
+    vsg::ref_ptr<vsg::MatrixTransform> square_transform;
+    vsg::ref_ptr<vsg::PointerEvent> lastPointerEvent;
+
+    SelectionMode selection_mode;
+    float square_scale;
+    bool dynamic_colours;
+
+    // Find the color node and change its color
+    struct ResetColor : public vsg::Visitor
+    {
+        void apply(vsg::Object& object) override
+        {
+            object.traverse(*this);
+        }
+
+        void apply(vsg::VertexDraw& vd) override
+        {
+            for (auto& buffer : vd.arrays)
+            {
+                auto data = buffer->data;
+                if (data->is_compatible(typeid(vsg::ubvec4Array)))
+                {
+                    auto colors = data.cast<vsg::ubvec4Array>();
+                    for (int i = 0; i < colors->size(); i++)
+                        colors->at(i) = vsg::ubvec4(0, 255, 0, 255);
+
+                    colors->dirty();
+                }
+            }
+        }
+    };
+
+    SelectionHandler(vsg::ref_ptr<vsg::Camera> in_camera, vsg::ref_ptr<vsg::Group> in_scenegraph, bool in_dynamic_colours) :
+        camera(in_camera), scenegraph(in_scenegraph), selection_mode(NONE), square_scale(40.f), dynamic_colours(in_dynamic_colours)
+    {
+        auto stateGroup = create_wirefame_stateGroup();
+        scenegraph->addChild(stateGroup);
+
+        // Polygon selection vertices
+        poly_vertices = vsg::vec3Array::create(MAX_POLYGON_VERTICES);
+        poly_vertices->properties.dataVariance = vsg::DYNAMIC_DATA;
+        poly_vertexDraw = vsg::VertexDraw::create();
+        poly_vertexDraw->assignArrays({poly_vertices});
+        poly_vertexDraw->vertexCount = 0;
+        poly_vertexDraw->instanceCount = 1;
+        polygon_switch = vsg::Switch::create();
+        polygon_switch->addChild(false, poly_vertexDraw);
+        stateGroup->addChild(polygon_switch);
+
+        // Square selection
+        auto square_vertices = vsg::vec3Array::create({{-1.0f, -1.0f, 0.f}, {1.0f, -1.0f, 0.f}, {1.0f, 1.0f, 0.f}, {-1.0, 1.0, 0.f}, { -1.0f, -1.0, 0.f}});
+        auto square_vertexDraw = vsg::VertexDraw::create();
+        square_vertexDraw->assignArrays({square_vertices});
+        square_vertexDraw->vertexCount = square_vertices->width();
+        square_vertexDraw->instanceCount = 1;
+        square_vertexDraw->vertexCount = 5;
+
+        square_transform = vsg::MatrixTransform::create();
+        square_transform->matrix = vsg::scale(square_scale);
+        square_transform->addChild(square_vertexDraw);
+        square_switch = vsg::Switch::create();
+        square_switch->addChild(false, square_transform);
+        stateGroup->addChild(square_switch);
+    }
+
+    void apply(vsg::KeyPressEvent& keyPress) override
+    {
+        auto previous_mode = selection_mode;
+
+        if (keyPress.keyBase == vsg::KEY_1)
+        {
+            selection_mode = selection_mode == SQUARE ? NONE : SQUARE;
+            square_switch->setAllChildren(selection_mode == SQUARE ? true : false);
+        }
+        else if (keyPress.keyBase == vsg::KEY_2)
+        {
+            if (selection_mode == NONE && polygon_switch->children[0].mask == vsg::boolToMask(true))
+            {
+                poly_vertexDraw->vertexCount = 0;
+                poly_vertices->dirty();
+                polygon_switch->setAllChildren(false);
+            }
+            else
+                selection_mode = selection_mode == POLYGON ? NONE : POLYGON;
+        }
+        else if (keyPress.keyBase == vsg::KEY_o)
+        {
+            if (polygon_switch->children[0].mask == vsg::boolToMask(true))
+            {
+                std::vector<vsg::dvec2> polygon(poly_vertexDraw->vertexCount);
+                for (uint32_t i = 0; i < poly_vertexDraw->vertexCount; i++)
+                    polygon[i] = vsg::dvec2(poly_vertices->at(i).x, poly_vertices->at(i).y);
+
+                polygonIntersect(polygon, true);
+            }
+        }
+        else if (keyPress.keyBase == vsg::KEY_r)
+        {
+            if (dynamic_colours)
+            {
+                ResetColor rc;
+                scenegraph->accept(rc);
+            }
+        } 
+
+        if (previous_mode != selection_mode && selection_mode != NONE)
+        {
+            polygon_switch->setAllChildren(selection_mode == POLYGON ? true : false);
+            square_switch->setAllChildren(selection_mode == SQUARE ? true : false);
+        }
+    }
+
+    void apply(vsg::MoveEvent& moveEvent) override
+    {
+        lastPointerEvent = &moveEvent;
+        if (selection_mode == POLYGON)
+        {
+            if (poly_vertexDraw->vertexCount > 2)
+            {
+                poly_vertices->at(poly_vertexDraw->vertexCount - 2) = vsg::vec3(static_cast<float>(moveEvent.x), static_cast<float>(moveEvent.y), 0.f);
+                poly_vertices->dirty();
+                moveEvent.handled = true;
+            }
+        }
+        square_transform->matrix = vsg::translate(vsg::vec3(static_cast<float>(moveEvent.x), static_cast<float>(moveEvent.y), 0.f)) * vsg::scale(square_scale);
+    }
+
+   void apply(vsg::ScrollWheelEvent& scrollWheel) override
+    {
+        if (selection_mode == SQUARE)
+        {
+            scrollWheel.handled = true;
+            float scale = square_scale * (1.f + scrollWheel.delta.y * 0.1f);
+            if (scale < 2.0 || scale > 300.0)
+                return;
+
+            square_scale = scale;
+            square_transform->matrix = vsg::translate(vsg::vec3(static_cast<float>(lastPointerEvent->x), static_cast<float>(lastPointerEvent->y), 0.f)) * vsg::scale(square_scale);
+        }
+    }
+
+    void apply(vsg::ButtonPressEvent& buttonPress) override
+    {
+        if (buttonPress.button == 1)
+        {
+            switch (selection_mode)
+            {
+            case NONE:
+                if (poly_vertexDraw->vertexCount > 0)
+                {
+                    polygon_switch->setAllChildren(false);
+                    poly_vertexDraw->vertexCount = 0;
+                    poly_vertices->dirty();
+                }
+                break;
+
+            case POLYGON:
+                if (poly_vertexDraw->vertexCount == 0)
+                {
+                    poly_vertices->set(0, vsg::vec3(static_cast<float>(buttonPress.x), static_cast<float>(buttonPress.y), 0.f));
+                    poly_vertices->set(1, vsg::vec3(static_cast<float>(buttonPress.x), static_cast<float>(buttonPress.y), 0.f));
+                    poly_vertices->set(2, vsg::vec3(static_cast<float>(buttonPress.x), static_cast<float>(buttonPress.y), 0.f));
+                    poly_vertexDraw->vertexCount = 3;
+                    poly_vertices->dirty();
+                }
+                else
+                {
+                    poly_vertexDraw->vertexCount++;
+                    poly_vertices->at(poly_vertexDraw->vertexCount - 2) = vsg::vec3(static_cast<float>(buttonPress.x), static_cast<float>(buttonPress.y), 0.f);
+                    poly_vertices->at(poly_vertexDraw->vertexCount - 1) = poly_vertices->at(0);
+                    poly_vertices->dirty();
+                }
+                break;
+            }
+        }
+        else if (buttonPress.button == 3)
+        {
+           if (square_switch->children[0].mask == vsg::boolToMask(true))
+            {
+                auto m = square_transform->matrix;
+                auto minPt = m * vsg::dvec3(-1.0f, -1.0f, 0.f);
+                auto maxPt = m * vsg::dvec3(1.0f, 1.0f, 0.f);
+
+                polytopeIntersect(std::round(minPt.x), std::round(minPt.y), std::round(maxPt.x), std::round(maxPt.y));
+                buttonPress.handled = true;
+            }
+            else if (polygon_switch->children[0].mask == vsg::boolToMask(true))
+            {
+                std::vector<vsg::dvec2> polygon(poly_vertexDraw->vertexCount);
+                for (uint32_t i = 0; i < poly_vertexDraw->vertexCount; i++)
+                    polygon[i] = vsg::dvec2(poly_vertices->at(i).x, poly_vertices->at(i).y);
+
+                polygonIntersect(polygon);
+
+                buttonPress.handled = true;
+            }
+            else if (selection_mode == NONE)
+            {
+                cursorIntersect(static_cast<double>(buttonPress.x), static_cast<double>(buttonPress.y));
+
+                buttonPress.handled = true;
+            }
+        }
+    }
+
+    void cursorIntersect(double x, double y)
+    {
+        double size = 5;
+        auto intersector = vsgPoints::PointsPolytopeIntersector::create(*camera, x - size, y - size, x + size, y + size);
+        auto before_t = vsg::clock::now();
+        scenegraph->accept(*intersector);
+        double duration = std::chrono::duration<double, std::chrono::milliseconds::period>(vsg::clock::now() - before_t).count();
+
+        if (intersector->intersections.size() > 0)
+            std::cout <<std::fixed<<std::setprecision(4)<< "Picked point: " << intersector->intersections[0]->worldIntersection << std::endl;
+    }
+
+    void polytopeIntersect(double minX, double minY, double maxX, double maxY)
+    {
+        auto intersector = vsgPoints::PointsPolytopeIntersector::create(*camera, minX, minY, maxX, maxY);
+
+        auto before_t = vsg::clock::now();
+        scenegraph->accept(*intersector);
+        double duration = std::chrono::duration<double, std::chrono::milliseconds::period>(vsg::clock::now() - before_t).count();
+
+        if (intersector->intersections.size() > 0)
+            std::cout << std::fixed << std::setprecision(4) << "Polytope Intersected: " << intersector->intersections.size() << " points in " << duration << "ms"<<
+            ", First: " << intersector->intersections[0]->worldIntersection << std::endl;
+        else
+            std::cout << "Polytope Intersected: " << intersector->intersections.size() << " points in " << duration << "ms" << std::endl;
+
+        if (dynamic_colours)
+        {
+            for (auto& intersection : intersector->intersections)
+            {
+                intersection->arrays[2]->cast<vsg::ubvec4Array>()->set(intersection->indices[0], vsg::ubvec4(255, 0, 0, 255));
+                intersection->arrays[2]->dirty();
+            }
+        }
+    }
+
+    void polygonIntersect(std::vector<vsg::dvec2> polygon, bool invert_selection = false)
+    {
+        auto intersector = vsgPoints::PolygonIntersector::create(*camera, polygon);
+        intersector->invert_selection = invert_selection;
+        auto before_t = vsg::clock::now();
+        scenegraph->accept(*intersector);
+        double duration = std::chrono::duration<double, std::chrono::milliseconds::period>(vsg::clock::now() - before_t).count();
+
+        if (intersector->intersectionCount() > 0)
+        {
+            auto worldPos = intersector->intersections[0]->worldPos(intersector->intersections[0]->indices[0]);
+            std::cout << std::fixed << std::setprecision(4) << "Polygon Intersected: " << intersector->intersectionCount() << " points in " << duration << "ms"
+                << ", First: " << worldPos << std::endl;
+        }
+        else
+            std::cout << "Polygon Intersected: " << intersector->intersectionCount() << " points in " << duration << "ms" << std::endl;
+
+        if (dynamic_colours)
+        {
+            for (auto& intersection : intersector->intersections)
+            {
+                for (uint32_t i = 0; i < intersection->indices.size(); i++)
+                {
+                    intersection->arrays[2]->cast<vsg::ubvec4Array>()->set(intersection->indices[i], vsg::ubvec4(255, 0, 0, 255));
+                    intersection->arrays[2]->dirty();
+                }
+            }
+        }
+    }
+};
+
+
+vsg::ref_ptr<vsg::Group> create_scene(vsg::ref_ptr<vsgPoints::Settings> settings, vsg::dvec3 offset = vsg::dvec3(0.0, 0.0, 0.0))
+{
+    auto group = vsg::Group::create();
+    auto bricks = vsgPoints::Bricks::create(settings);
+    double seperation = 20.0 * settings->precision;
+    auto brick_size = settings->precision * pow(2.0, settings->bits);
+    double separation = brick_size / 100.0;
+
+    for (int x = -500; x < 500; ++x)
+    {
+        for (int y = -500; y < 500; ++y)
+        {
+            double z = (static_cast<double>(rand()%100)/10000.0);
+            bricks->add(vsg::dvec3(offset.x + x * seperation, offset.y + y * seperation, offset.z + z), vsg::ubvec4(0, 255, 0, 255));
+        }
+    }
+
+    group->addChild(vsgPoints::createSceneGraph(bricks, settings));
+    return group;
+}
+
+
+int main(int argc, char** argv)
+{
+    // set up defaults and read command line arguments to override them
+    vsg::CommandLine arguments(&argc, argv);
+
+    auto options = vsg::Options::create();
+    options->paths = vsg::getEnvPaths("VSG_FILE_PATH");
+    options->sharedObjects = vsg::SharedObjects::create();
+
+    options->add(vsgPoints::BIN::create());
+    options->add(vsgPoints::AsciiPoints::create());
+
+#ifdef vsgXchange_all
+    // add vsgXchange's support for reading and writing 3rd party file formats
+    options->add(vsgXchange::all::create());
+#endif
+
+    arguments.read(options);
+
+    if (int type; arguments.read("--allocator", type)) vsg::Allocator::instance()->allocatorType = vsg::AllocatorType(type);
+    if (size_t objectsBlockSize; arguments.read("--objects", objectsBlockSize)) vsg::Allocator::instance()->setBlockSize(vsg::ALLOCATOR_AFFINITY_OBJECTS, objectsBlockSize);
+    if (size_t nodesBlockSize; arguments.read("--nodes", nodesBlockSize)) vsg::Allocator::instance()->setBlockSize(vsg::ALLOCATOR_AFFINITY_NODES, nodesBlockSize);
+    if (size_t dataBlockSize; arguments.read("--data", dataBlockSize)) vsg::Allocator::instance()->setBlockSize(vsg::ALLOCATOR_AFFINITY_DATA, dataBlockSize);
+
+    auto windowTraits = vsg::WindowTraits::create();
+    windowTraits->windowTitle = "vsgpoints";
+    windowTraits->debugLayer = arguments.read({"--debug", "-d"});
+    windowTraits->apiDumpLayer = arguments.read({"--api", "-a"});
+    if (arguments.read("--test"))
+    {
+        windowTraits->swapchainPreferences.presentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+        windowTraits->fullscreen = true;
+    }
+    if (arguments.read({"--st", "--small-test"}))
+    {
+        windowTraits->swapchainPreferences.presentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+        windowTraits->width = 192, windowTraits->height = 108;
+        windowTraits->decoration = false;
+    }
+    auto maxPagedLOD = arguments.value(0, "--maxPagedLOD");
+
+    // set up the Settings used to guide how point clouds are setup in the scene graph
+    auto settings = vsgPoints::Settings::create();
+    options->setObject("settings", settings);
+    settings->options = vsg::Options::create(*options);
+
+    auto vsg_scene = vsg::Group::create();
+
+    if (arguments.argc() > 1)
+    {
+        vsg::Path filename = arguments[1];
+        auto scene = vsg::read_cast<vsg::Node>(filename, options);
+        if (scene)
+            vsg_scene->addChild(scene);
+    }
+
+    bool dynamic_colours = false;
+
+    if (vsg_scene->children.empty())
+    {
+        settings->bits = 10;
+        settings->createType = vsgPoints::CREATE_FLAT;
+        settings->precision = 0.001;
+        vsg_scene = create_scene(settings);
+
+        // Set color arrays as dynamic
+        struct SetDynamicColor : public vsg::Visitor
+        {
+            void apply(vsg::Object& object) override
+            {
+                object.traverse(*this);
+            }
+
+            void apply(vsg::VertexDraw& vd) override
+            {
+                for (auto& buffer : vd.arrays)
+                {
+                    auto data = buffer->data;
+                    if (data->is_compatible(typeid(vsg::ubvec4Array)))
+                        data->properties.dataVariance = vsg::DYNAMIC_DATA;
+                }
+            }
+        };
+        SetDynamicColor dc;
+        vsg_scene->accept(dc);
+        dynamic_colours = true;
+    }
+
+    if (vsg_scene->children.empty())
+    {
+        std::cout<<"Error: no data loaded."<<std::endl;
+        return 1;
+    }
+
+    auto viewer = vsg::Viewer::create();
+    auto window = vsg::Window::create(windowTraits);
+    if (!window)
+    {
+        std::cout << "Could not create window." << std::endl;
+        return 1;
+    }
+
+    viewer->addWindow(window);
+
+    // compute the bounds of the scene graph to help position camera
+    vsg::dbox bounds = vsg::visit<vsg::ComputeBounds>(vsg_scene).bounds;
+
+    vsg::dvec3 center = (bounds.min + bounds.max) * 0.5;
+    double radius = vsg::length(bounds.max - bounds.min) * 0.6;
+    double nearFarRatio = 0.001;
+
+    auto lookAt = vsg::LookAt::create(center + vsg::dvec3(0.0, -radius * 3.5, 0.0), center, vsg::dvec3(0.0, 0.0, 1.0));
+    auto perspective  = vsg::Perspective::create(30.0, static_cast<double>(window->extent2D().width) / static_cast<double>(window->extent2D().height), nearFarRatio * radius, radius * 4.5);
+
+    auto camera = vsg::Camera::create(perspective, lookAt, vsg::ViewportState::create(window->extent2D()));
+
+    auto view = vsg::View::create(camera);
+    view->addChild(vsg::createHeadlight());
+    view->addChild(vsg_scene);
+
+    // overlay camera
+    auto overlay_projection = vsg::Orthographic::create(0, window->extent2D().width, window->extent2D().height, 0, 100.0, 0.0);
+    auto overlay_lookAt = vsg::LookAt::create(vsg::dvec3(0.0, 0.0, 80.0), vsg::dvec3(0.0, 0.0, 0.0), vsg::dvec3(0.0, 1.0, 0.0));
+    auto overlay_camera = vsg::Camera::create(overlay_projection, overlay_lookAt, vsg::ViewportState::create(window->extent2D()));
+    auto overlay_scene = vsg::Group::create();
+    auto overlay_view = vsg::View::create(overlay_camera, overlay_scene);
+    overlay_view->addChild(overlay_scene);
+
+    // add close handler to respond to the close window button and pressing escape
+    viewer->addEventHandler(vsg::CloseHandler::create(viewer));
+
+    auto selectionHandler = SelectionHandler::create(camera, vsg_scene, dynamic_colours); 
+    overlay_scene->addChild(selectionHandler->polygon_switch);
+    overlay_scene->addChild(selectionHandler->square_switch);
+    viewer->addEventHandler(selectionHandler);
+
+    auto resize_handler = ResizeHandler::create(overlay_camera);
+    viewer->addEventHandler(resize_handler);
+
+    viewer->addEventHandler(vsg::Trackball::create(camera));
+
+    auto commandGraph = vsg::CommandGraph::create(window);
+    auto renderGraph = vsg::RenderGraph::create(window);
+    commandGraph->addChild(renderGraph);
+
+    renderGraph->addChild(view);
+    renderGraph->addChild(overlay_view);
+
+    viewer->assignRecordAndSubmitTaskAndPresentation({commandGraph});
+
+    viewer->compile();
+
+    if (maxPagedLOD > 0)
+    {
+        // set targetMaxNumPagedLODWithHighResSubgraphs after Viewer::compile() as it will assign any DatabasePager if required.
+        for(auto& task : viewer->recordAndSubmitTasks)
+        {
+            if (task->databasePager) task->databasePager->targetMaxNumPagedLODWithHighResSubgraphs = maxPagedLOD;
+        }
+    }
+
+    viewer->start_point() = vsg::clock::now();
+
+    // rendering main loop
+    while (viewer->advanceToNextFrame())
+    {
+        // pass any events into EventHandlers assigned to the Viewer
+        viewer->handleEvents();
+
+        viewer->update();
+
+        viewer->recordAndSubmit();
+
+        viewer->present();
+    }
+
+    auto fs = viewer->getFrameStamp();
+    double fps = static_cast<double>(fs->frameCount) / std::chrono::duration<double, std::chrono::seconds::period>(vsg::clock::now() - viewer->start_point()).count();
+    std::cout<<"Average frame rate = "<<fps<<" fps"<<std::endl;
+
+    return 0;
+}

--- a/include/vsgPoints/utils/PointsPolytopeIntersector.h
+++ b/include/vsgPoints/utils/PointsPolytopeIntersector.h
@@ -1,0 +1,35 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2025 Jamie Robertson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/utils/PolytopeIntersector.h>
+
+#include <vsg/core/Inherit.h>
+#include <vsgPoints/Export.h>
+
+namespace vsgPoints
+{   
+    /// PointsPolytopeIntersector is an vsg::PolytopeIntersector subclass that provides support for vsgPoints pointclouds with packed vertex formats 
+    class VSGPOINTS_DECLSPEC PointsPolytopeIntersector : public vsg::Inherit<vsg::PolytopeIntersector, PointsPolytopeIntersector>
+    {
+    public:
+        using Inherit::Inherit;
+
+        vsg::ref_ptr<Intersection> add(const vsg::dvec3& coord, const vsg::dmat4& in_localToWorld, const std::vector<uint32_t>& indices, uint32_t instanceIndex);
+
+        void apply(const vsg::VertexDraw& vid) override;
+    };
+
+} // namespace vsgPoints
+
+EVSG_type_name(vsgPoints::PointsPolytopeIntersector)

--- a/include/vsgPoints/utils/PolygonIntersector.h
+++ b/include/vsgPoints/utils/PolygonIntersector.h
@@ -1,0 +1,79 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2025 Jamie Robertson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsgPoints/Export.h>
+
+#include <vsg/maths/plane.h>
+#include <vsg/utils/Intersector.h>
+
+
+namespace vsgPoints
+{
+    using Edge = std::vector<vsg::dvec3>;
+    using Edges = std::vector<std::vector<vsg::dvec3>>;
+    using Polytope = std::vector<vsg::dplane>;
+
+    class VSGPOINTS_DECLSPEC PolygonIntersector : public vsg::Inherit<vsg::Intersector, PolygonIntersector>
+    {
+    public:
+        /// create a vsgPoints intersector for a screen polygon with window space dimensions projected into world coords using the Camera's projection and view matrices.
+        PolygonIntersector(const vsg::Camera& camera, std::vector<vsg::dvec2> polygon, vsg::ref_ptr<vsg::ArrayState> initialArrayData = {});
+
+        class VSGPOINTS_DECLSPEC Intersection : public Inherit<Object, Intersection>
+        {
+        public:
+            Intersection() {}
+            Intersection(const vsg::dmat4& in_localToWorld,const NodePath& in_nodePath, const vsg::DataList& in_arrays,
+                const std::vector<uint32_t>& in_indices, uint32_t in_instanceIndex);
+
+            vsg::dmat4 localToWorld;
+            NodePath nodePath;
+            vsg::DataList arrays;
+            std::vector<uint32_t> indices;
+            uint32_t instanceIndex = 0;
+
+            // return true if Intersection is valid
+            operator bool() const { return !nodePath.empty(); }
+
+            vsg::dvec3 worldPos(uint32_t index);
+        };
+
+        bool invert_selection;
+
+        using Intersections = std::vector<vsg::ref_ptr<Intersection>>;
+        Intersections intersections;
+
+        uint64_t intersectionCount();
+
+        vsg::ref_ptr<Intersection> add(const vsg::dmat4& in_localToWorld, const std::vector<uint32_t>& indices, uint32_t instanceIndex);
+
+        void pushTransform(const vsg::Transform& transform) override;
+        void popTransform() override;
+
+        bool intersects(const vsg::dsphere& bs) override;
+
+        bool intersectDraw(uint32_t firstVertex, uint32_t vertexCount, uint32_t firstInstance, uint32_t instanceCount) override;
+
+        bool intersectDrawIndexed(uint32_t firstIndex, uint32_t indexCount, uint32_t firstInstance, uint32_t instanceCount) override;
+
+        void apply(const vsg::VertexDraw& vid) override;
+
+    protected:
+        std::vector<Polytope> _polytopeStack;
+        std::vector<Edges> _polygonEdgeStack;
+    };
+
+} // namespace vsgPoints
+
+EVSG_type_name(vsgPoints::PolygonIntersector)

--- a/src/vsgPoints/CMakeLists.txt
+++ b/src/vsgPoints/CMakeLists.txt
@@ -14,6 +14,8 @@ set(HEADERS
     ${HEADER_PATH}/BrickShaderSet.h
     ${HEADER_PATH}/Settings.h
     ${HEADER_PATH}/create.h
+    ${HEADER_PATH}/utils/PointsPolytopeIntersector.h
+    ${HEADER_PATH}/utils/PolygonIntersector.h
  )
 
 set(SOURCES
@@ -23,7 +25,23 @@ set(SOURCES
     Bricks.cpp
     BrickShaderSet.cpp
     create.cpp
+    utils/PointsPolytopeIntersector.cpp
+    utils/PolygonIntersector.cpp
 )
+
+# Group utils sub directories
+foreach(header ${HEADERS})
+    if (header MATCHES ".*/utils/.*")
+        source_group("Header Files/utils" FILES ${header})
+    endif()
+endforeach()
+
+foreach(source ${SOURCES})
+    if (source MATCHES "utils/.*")
+        # Explicitly group "utils" sources under "Source Files"
+        source_group("Source Files/utils" FILES ${source})
+    endif()
+endforeach()
 
 add_library(vsgPoints ${HEADERS} ${SOURCES})
 

--- a/src/vsgPoints/utils/PointsPolytopeIntersector.cpp
+++ b/src/vsgPoints/utils/PointsPolytopeIntersector.cpp
@@ -1,0 +1,134 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2025 Jamie Robertson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsgPoints/utils/PointsPolytopeIntersector.h>
+
+#include <vsg/nodes/vertexdraw.h>
+
+#include <iostream>
+
+using namespace vsgPoints;
+
+struct PushPopNode
+{
+    vsg::Intersector::NodePath& nodePath;
+
+    PushPopNode(vsg::Intersector::NodePath& np, const vsg::Node* node) :
+        nodePath(np) { nodePath.push_back(node); }
+    ~PushPopNode() { nodePath.pop_back(); }
+};
+
+vsg::ref_ptr<vsg::PolytopeIntersector::Intersection> PointsPolytopeIntersector::add(const vsg::dvec3& coord, const vsg::dmat4& localToWorld, 
+    const std::vector<uint32_t>& indices, uint32_t instanceIndex)
+{
+    vsg::ref_ptr<Intersection> intersection;
+    intersection = Intersection::create(coord, localToWorld * coord, localToWorld, _nodePath, arrayStateStack.back()->arrays, indices, instanceIndex);
+    intersections.emplace_back(intersection);
+
+    return intersection;
+}
+
+void PointsPolytopeIntersector::apply(const vsg::VertexDraw& vid)
+{
+    auto& arrayState = *arrayStateStack.back();
+    arrayState.apply(vid);
+    if (!arrayState.vertices)
+    {
+        if (arrayState.topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST && arrayState.arrays.size() > 4)
+        {
+            auto ps = arrayState.arrays[arrayState.arrays.size() - 2];
+            if (!ps->is_compatible(typeid(vsg::vec4Value)))
+                return;
+
+            vsg::vec4 posScale = ps->cast<vsg::vec4Value>()->value();
+
+            if (arrayState.vertexAttribute.format == VK_FORMAT_R8G8B8_UNORM ||
+                arrayState.vertexAttribute.format == VK_FORMAT_A2R10G10B10_UNORM_PACK32 ||
+                arrayState.vertexAttribute.format == VK_FORMAT_R16G16B16_UNORM)
+            {
+                PushPopNode ppn(_nodePath, &vid);
+
+                double divisor = 1.0;
+                switch (arrayState.vertexAttribute.format)
+                {
+                case VK_FORMAT_R8G8B8_UNORM:
+                    divisor = pow(2.f, 8.f) - 1;
+                    break;
+                case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+                    divisor = pow(2.f, 10.f) - 1;
+                    break;
+                case VK_FORMAT_R16G16B16_UNORM:
+                    divisor = pow(2.f, 16.f) - 1;
+                    break;
+                }
+
+                // Matrix for unpacking packed vertices
+                vsg::dmat4 localToWorld = vsg::translate(vsg::dvec3(posScale.x, posScale.y, posScale.z)) * vsg::scale(posScale.w / divisor);
+
+                auto polytope = _polytopeStack.back();
+                for (auto& pl : polytope)
+                {
+                    pl = pl * localToWorld;
+                }
+
+                localToWorld = computeTransform(_nodePath) * localToWorld;
+
+                auto processVertices = [&](auto src_vertices, auto getVertex) {
+                    uint32_t lastIndex = vid.instanceCount > 1 ? (vid.firstInstance + vid.instanceCount) : vid.firstInstance + 1;
+                    for (uint32_t inst = vid.firstInstance; inst < lastIndex; ++inst)
+                    {
+                        uint32_t endVertex = vid.firstVertex + vid.vertexCount;
+                        for (uint32_t i = vid.firstVertex; i < endVertex; ++i)
+                        {
+                            auto vertex = getVertex(src_vertices->at(i));
+                            if (vsg::inside(polytope, vertex))
+                            {
+                                add(vsg::dvec3(vertex), localToWorld, {i}, inst);
+                            }
+                        }
+                    }
+                };
+
+                switch (arrayState.vertexAttribute.format)
+                {
+                case VK_FORMAT_R8G8B8_UNORM: {
+                    auto src_vertices = arrayState.arrays[arrayState.vertexAttribute.binding].cast<vsg::ubvec3Array>();
+                    processVertices(src_vertices, [](const vsg::ubvec3& sv) {
+                        return vsg::dvec3(static_cast<double>(sv.x), static_cast<double>(sv.y), static_cast<double>(sv.z));
+                    });
+                }
+                break;
+                case VK_FORMAT_A2R10G10B10_UNORM_PACK32: {
+                    auto src_vertices = arrayState.arrays[arrayState.vertexAttribute.binding].cast<vsg::uintArray>();
+                    processVertices(src_vertices, [](const uint32_t& sv) {
+                        return vsg::dvec3(static_cast<double>((sv >> 20) & 0x3FF), static_cast<double>((sv >> 10) & 0x3FF), static_cast<double>(sv & 0x3FF));
+                    });
+                }
+                break;
+                case VK_FORMAT_R16G16B16_UNORM: {
+                    auto src_vertices = arrayState.arrays[arrayState.vertexAttribute.binding].cast<vsg::usvec3Array>();
+                    processVertices(src_vertices, [](const vsg::usvec3& sv) {
+                        return vsg::dvec3(static_cast<double>(sv.x), static_cast<double>(sv.y), static_cast<double>(sv.z));
+                    });
+                }
+                break;
+                }
+                return;
+            }
+            else
+                return;
+        }
+    }
+    PushPopNode ppn(_nodePath, &vid);
+
+    intersectDraw(vid.firstVertex, vid.vertexCount, vid.firstInstance, vid.instanceCount);
+}

--- a/src/vsgPoints/utils/PolygonIntersector.cpp
+++ b/src/vsgPoints/utils/PolygonIntersector.cpp
@@ -1,0 +1,487 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2025 Jamie Robertson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsgPoints/utils/PolygonIntersector.h>
+
+#include <vsg/app/Camera.h>
+#include <vsg/nodes/Transform.h>
+#include <vsg/nodes/vertexdraw.h>
+
+#include <iostream>
+
+using namespace vsgPoints;
+
+struct PushPopNode
+{
+    vsg::Intersector::NodePath& nodePath;
+
+    PushPopNode(vsg::Intersector::NodePath& np, const vsg::Node* node) :
+        nodePath(np) { nodePath.push_back(node); }
+    ~PushPopNode() { nodePath.pop_back(); }
+};
+
+struct RayTriangleIntersector
+{
+    vsg::dvec3 d, v0, v1, v2, e1, e2, h;
+    double a;
+
+    RayTriangleIntersector():a(0.0){}
+
+    RayTriangleIntersector(const vsg::dvec3& in_ray_dir, const vsg::dvec3& in_v0, const vsg::dvec3& in_v1, const vsg::dvec3& in_v2) : 
+        d(in_ray_dir), v0(in_v0), v1(in_v1), v2(in_v2)
+    {
+        e1 = v1 - v0;
+        e2 = v2 - v0;
+        h = vsg::cross(in_ray_dir, e2);
+        a = vsg::dot(e1, h);
+    }
+
+    bool intersectsTriangle(const vsg::dvec3& pt)
+    {
+        const double epsilon = 1e-10;
+        if (a > -epsilon && a < epsilon)
+            return (false);
+
+        double f = 1.0 / a;
+        vsg::dvec3 s = pt - v0;
+        double u = f * (vsg::dot(s, h));
+            
+        if (u < 0.0 || u > 1.0)
+            return (false);
+            
+        vsg::dvec3 q = vsg::cross(s, e1);
+        double v = f * vsg::dot(d, q);
+            
+        if (v < 0.0 || u + v > 1.0)
+            return (false);
+
+        double t = f * dot(e2, q);
+            
+        return (t > epsilon);
+    }
+};
+
+struct RayEdgeIntersector
+{
+    RayTriangleIntersector t1;
+    RayTriangleIntersector t2;
+
+    vsg::dvec3 plane_normal;
+    double dot_normal_ray;
+
+
+    RayEdgeIntersector(const vsg::dvec3& in_ray_dir, const vsg::dvec3& in_v0, const vsg::dvec3& in_v1, const vsg::dvec3& in_v2, const vsg::dvec3& in_v3)
+        : t1(RayTriangleIntersector(in_ray_dir, in_v0, in_v2, in_v3)), t2(RayTriangleIntersector(in_ray_dir, in_v0, in_v1, in_v2))
+    {
+        plane_normal = vsg::cross(t1.e1, t1.e2);
+        dot_normal_ray = vsg::dot(plane_normal, in_ray_dir);
+    }
+
+    bool intersects(const vsg::dvec3& pt)
+    {
+        double dot_normal_point = vsg::dot(plane_normal, pt - t1.v0);
+        if (dot_normal_ray * dot_normal_point > 0)
+            return false;
+
+        return t1.intersectsTriangle(pt) || t2.intersectsTriangle(pt);
+    }
+};
+
+
+PolygonIntersector::PolygonIntersector(const vsg::Camera& camera, std::vector<vsg::dvec2> polygon, vsg::ref_ptr<vsg::ArrayState> initialArrayData) :
+    Inherit(initialArrayData)
+{
+    invert_selection = false;
+
+    auto viewport = camera.getViewport();
+
+    std::vector<vsg::dvec2> ndc_polygon;
+    vsg::dbox ndc_bounds;
+    for (auto& pt : polygon)
+    {
+        double ndc_x = (viewport.width > 0) ? (2.0 * (pt.x - static_cast<double>(viewport.x)) / static_cast<double>(viewport.width) - 1.0) : pt.x;
+        double ndc_y = (viewport.height > 0) ? (2.0 * (pt.y - static_cast<double>(viewport.y)) / static_cast<double>(viewport.height) - 1.0) : pt.y;
+        vsg::dvec2 ndc(ndc_x, ndc_y);
+        if (ndc_polygon.size() > 0 && ndc == ndc_polygon.back())
+            continue;
+        ndc_polygon.push_back(ndc);
+        ndc_bounds.add(ndc.x, ndc.y, 0.0);
+    }
+
+    // Ensure closed
+    if (!ndc_polygon.empty() && ndc_polygon.front() != ndc_polygon.back())
+        ndc_polygon.push_back(ndc_polygon.front());
+
+    if (ndc_polygon.size() < 3)
+        ndc_polygon.clear();
+
+    auto projectionMatrix = camera.projectionMatrix->transform();
+    auto viewMatrix = camera.viewMatrix->transform();
+    bool reverse_depth = (projectionMatrix(2, 2) > 0.0);
+
+    double ndc_near = reverse_depth ? viewport.maxDepth : viewport.minDepth;
+    double ndc_far = reverse_depth ? viewport.minDepth : viewport.maxDepth;
+
+    Polytope clipspace;
+    clipspace.push_back(vsg::dplane(1.0, 0.0, 0.0, -ndc_bounds.min.x)); // left
+    clipspace.push_back(vsg::dplane(-1.0, 0.0, 0.0, ndc_bounds.max.x)); // right
+    clipspace.push_back(vsg::dplane(0.0, 1.0, 0.0, -ndc_bounds.min.y)); // bottom
+    clipspace.push_back(vsg::dplane(0.0, -1.0, 0.0, ndc_bounds.max.y)); // top
+    clipspace.push_back(vsg::dplane(0.0, 0.0, -1.0, ndc_near)); // near
+    clipspace.push_back(vsg::dplane(0.0, 0.0, 1.0, ndc_far));   // far
+
+    Polytope eyespace;
+    for (auto& pl : clipspace)
+    {
+        eyespace.push_back(pl * projectionMatrix);
+    }
+
+    _polytopeStack.push_back(eyespace);
+
+    Polytope worldspace;
+    for (auto& pl : eyespace)
+    {
+        worldspace.push_back(pl * viewMatrix);
+    }
+
+    _polytopeStack.push_back(worldspace);
+
+    vsg::dmat4 eyeToWorld = inverse(viewMatrix);
+    localToWorldStack().push_back(viewMatrix);
+    worldToLocalStack().push_back(eyeToWorld);
+
+    // edges
+    Edges clipEdges;
+
+    //   v1__v2
+    //   /    \
+    //  /______\
+    // v0      v3
+    for (int i = 1; i < ndc_polygon.size(); i++)
+    {
+        auto v0 = vsg::dvec3(ndc_polygon[i - 1].x, ndc_polygon[i - 1].y, ndc_near);
+        auto v1 = vsg::dvec3(ndc_polygon[i - 1].x, ndc_polygon[i - 1].y, ndc_far);
+        auto v2 = vsg::dvec3(ndc_polygon[i].x, ndc_polygon[i].y, ndc_far);
+        auto v3 = vsg::dvec3(ndc_polygon[i].x, ndc_polygon[i].y, ndc_near);
+        Edge edge = {v0, v1, v2, v3};
+        clipEdges.push_back(edge);
+    }
+
+    auto inv_projectionMatrix = vsg::inverse(projectionMatrix);
+    Edges eyeEdges;
+    for (auto& edge : clipEdges)
+    {
+        eyeEdges.push_back(Edge{inv_projectionMatrix * edge[0], inv_projectionMatrix * edge[1],
+                                inv_projectionMatrix * edge[2], inv_projectionMatrix * edge[3]});
+    }
+
+    _polygonEdgeStack.push_back(eyeEdges);
+
+    Edges worldEdges;
+    for (auto& edge : eyeEdges)
+    {
+        worldEdges.push_back(Edge{eyeToWorld * edge[0], eyeToWorld * edge[1],
+                                    eyeToWorld * edge[2], eyeToWorld * edge[3]});
+    }
+
+    _polygonEdgeStack.push_back(worldEdges);
+}
+
+PolygonIntersector::Intersection::Intersection(const vsg::dmat4& in_localToWorld, const NodePath& in_nodePath, const vsg::DataList& in_arrays, const std::vector<uint32_t>& in_indices, uint32_t in_instanceIndex) :
+    localToWorld(in_localToWorld),
+    nodePath(in_nodePath),
+    arrays(in_arrays),
+    indices(in_indices),
+    instanceIndex(in_instanceIndex)
+{
+}
+
+vsg::dvec3 PolygonIntersector::Intersection::worldPos(uint32_t index)
+{
+    switch (arrays[0]->properties.format)
+    {
+        case VK_FORMAT_R8G8B8_UNORM:
+            return localToWorld * vsg::dvec3(arrays[0].cast<vsg::ubvec3Array>()->at(index));
+            break;
+        case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+            {
+                uint32_t v = arrays[0].cast<vsg::uintArray>()->at(index);
+                return localToWorld * vsg::dvec3(static_cast<double>((v >> 20) & 0x3FF), static_cast<double>((v >> 10) & 0x3FF), static_cast<double>(v & 0x3FF));
+            }
+            break;
+        case VK_FORMAT_R16G16B16_UNORM:
+                return localToWorld * vsg::dvec3(arrays[0].cast<vsg::usvec3Array>()->at(index));
+            break;
+    }
+    return vsg::dvec3(0.0, 0.0, 0.0);
+}
+
+
+vsg::ref_ptr<PolygonIntersector::Intersection> PolygonIntersector::add(const vsg::dmat4& localToWorld, const std::vector<uint32_t>& indices, uint32_t instanceIndex)
+{
+    vsg::ref_ptr<Intersection> intersection;
+
+    intersection = Intersection::create(localToWorld, _nodePath, arrayStateStack.back()->arrays, indices, instanceIndex);
+    intersections.emplace_back(intersection);
+
+    return intersection;
+}
+
+uint64_t PolygonIntersector::intersectionCount()
+{
+    uint64_t count = 0;
+    for (auto& intersection : intersections)
+        count += intersection->indices.size();
+    return count;
+}
+
+void PolygonIntersector::pushTransform(const vsg::Transform& transform)
+{
+    auto& l2wStack = localToWorldStack();
+    auto& w2lStack = worldToLocalStack();
+
+    vsg::dmat4 localToWorld = l2wStack.empty() ? transform.transform(vsg::dmat4{}) : transform.transform(l2wStack.back());
+    vsg::dmat4 worldToLocal = inverse(localToWorld);
+
+    l2wStack.push_back(localToWorld);
+    w2lStack.push_back(worldToLocal);
+
+    // bounding polytope
+    const auto& worldspace_polytope = _polytopeStack.front();
+
+    Polytope localspace_polytope;
+    for (auto& pl : worldspace_polytope)
+    {
+        localspace_polytope.push_back(pl * localToWorld);
+    }
+
+    _polytopeStack.push_back(localspace_polytope);
+
+    // edges
+    const auto& worldspace_edges = _polygonEdgeStack.front();
+
+    Edges localspace_edges;
+    for (auto& edge : worldspace_edges)
+    {
+        localspace_edges.emplace_back(Edge{worldToLocal * edge[0], worldToLocal * edge[1], worldToLocal * edge[2], worldToLocal * edge[3]});
+    }
+    _polygonEdgeStack.push_back(localspace_edges);
+}
+
+void PolygonIntersector::popTransform()
+{
+    _polytopeStack.pop_back();
+    _polygonEdgeStack.pop_back();
+    localToWorldStack().pop_back();
+    worldToLocalStack().pop_back();
+}
+
+bool PolygonIntersector::intersects(const vsg::dsphere& bs)
+{
+    if (!bs.valid()) return false;
+
+    const auto& polytope = _polytopeStack.back();
+
+    return vsg::intersect(polytope, bs) || invert_selection;
+}
+
+bool PolygonIntersector::intersectDraw(uint32_t firstVertex, uint32_t vertexCount, uint32_t firstInstance, uint32_t instanceCount)
+{
+    return false;
+}
+
+bool PolygonIntersector::intersectDrawIndexed(uint32_t firstIndex, uint32_t indexCount, uint32_t firstInstance, uint32_t instanceCount)
+{
+    return false;
+}
+
+
+void PolygonIntersector::apply(const vsg::VertexDraw& vid)
+{
+    if (_polygonEdgeStack.back().empty())
+        return;
+
+    auto& arrayState = *arrayStateStack.back();
+    arrayState.apply(vid);
+    if (!arrayState.vertices)
+    {
+        if (arrayState.topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST && arrayState.arrays.size() > 4)
+        {
+            auto ps = arrayState.arrays[arrayState.arrays.size() - 2];
+            if (!ps->is_compatible(typeid(vsg::vec4Value)))
+                return;
+
+            vsg::vec4 posScale = ps->cast<vsg::vec4Value>()->value();
+
+            if (arrayState.vertexAttribute.format == VK_FORMAT_R8G8B8_UNORM ||
+                arrayState.vertexAttribute.format == VK_FORMAT_A2R10G10B10_UNORM_PACK32 ||
+                arrayState.vertexAttribute.format == VK_FORMAT_R16G16B16_UNORM)
+            {
+                PushPopNode ppn(_nodePath, &vid);
+
+                double divisor = 1.0;
+                switch (arrayState.vertexAttribute.format)
+                {
+                case VK_FORMAT_R8G8B8_UNORM:
+                    divisor = pow(2.f, 8.f) - 1;
+                    break;
+                case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+                    divisor = pow(2.f, 10.f) - 1;
+                    break;
+                case VK_FORMAT_R16G16B16_UNORM:
+                    divisor = pow(2.f, 16.f) - 1;
+                    break;
+                }
+
+                // Matrix for unpacking packed vertices
+                vsg::dmat4 localToWorld = vsg::translate(vsg::dvec3(posScale.x, posScale.y, posScale.z)) * vsg::scale(posScale.w / divisor);
+                vsg::dmat4 worldToLocal = vsg::inverse(localToWorld);
+
+                auto polytope = _polytopeStack.back();
+                for (auto& pl : polytope)
+                {
+                    pl = pl * localToWorld;
+                }
+
+                // transform edges to packed vertex coordinates
+                auto edges = _polygonEdgeStack.back();
+                for (auto& edge : edges)
+                {
+                    for (auto& v : edge)
+                    {
+                        v = worldToLocal * v;
+                        int a = 0;
+                    }
+                }
+
+                localToWorld = computeTransform(_nodePath) * localToWorld;
+
+                // test ray direction across near / far of first edge
+                //   v1__v2
+                //   /    \
+                //  /______\
+                // v0       v3
+                vsg::dvec3 ray_dir = vsg::normalize(vsg::cross(edges.front()[1] - edges.front()[0], edges.front()[3] - edges.front()[0]));
+                std::vector<RayEdgeIntersector> edgeIntersectors;
+
+                for (auto &edge : edges)
+                {
+                    edgeIntersectors.emplace_back(RayEdgeIntersector(ray_dir, edge[0], edge[1], edge[2], edge[3]));
+                }
+
+                // Test whether entire brick intersected
+                std::vector<vsg::dvec3> brickCorners ={
+                        vsg::dvec3(0.0, 0.0, 0.0),
+                        vsg::dvec3(0.0, 0.0, divisor),
+                        vsg::dvec3(divisor, 0.0, 0.0),
+                        vsg::dvec3(divisor, 0.0, divisor),
+                        vsg::dvec3(0.0, divisor, 0.0),
+                        vsg::dvec3(0.0, divisor, divisor),
+                        vsg::dvec3(divisor, divisor, 0.0),
+                        vsg::dvec3(divisor, divisor, divisor)};
+
+                bool all_intersected = true;
+                for (auto& v : brickCorners)
+                {
+                    int n_intersections = 0;
+                    for (auto& edgeIntersector : edgeIntersectors)
+                    {
+                        if (edgeIntersector.intersects(v))
+                            n_intersections++;
+                    }
+                    if (invert_selection && n_intersections % 2 == 1)
+                    {
+                        all_intersected = false;
+                        break;
+                    }
+                    else if (!invert_selection && n_intersections % 2 == 0)
+                    {
+                        all_intersected = false;
+                        break;
+                    }
+                }
+                if (all_intersected)
+                {
+                    uint32_t lastIndex = vid.instanceCount > 1 ? (vid.firstInstance + vid.instanceCount) : vid.firstInstance + 1;
+                    for (uint32_t inst = vid.firstInstance; inst < lastIndex; ++inst)
+                    {
+                        uint32_t endVertex = vid.firstVertex + vid.vertexCount;
+                        std::vector<uint32_t> intersectedIndices;
+                        for (uint32_t i = vid.firstVertex; i < endVertex; ++i)
+                            intersectedIndices.push_back(i);
+
+                        if (!intersectedIndices.empty())
+                            add(localToWorld, intersectedIndices, inst);
+                    }
+                    return;
+                }
+
+                auto processVertices = [&](auto src_vertices, auto getVertex) {
+                    uint32_t lastIndex = vid.instanceCount > 1 ? (vid.firstInstance + vid.instanceCount) : vid.firstInstance + 1;
+                    for (uint32_t inst = vid.firstInstance; inst < lastIndex; ++inst)
+                    {
+                        uint32_t endVertex = vid.firstVertex + vid.vertexCount;
+                        std::vector<uint32_t> intersectedIndices;
+                        for (uint32_t i = vid.firstVertex; i < endVertex; ++i)
+                        {
+                            auto vertex = getVertex(src_vertices->at(i));
+                            if (invert_selection || edgeIntersectors.size() < 9 || vsg::inside(polytope, vertex))
+                            {
+                                int n_intersections = 0;
+                                for (auto& edgeIntersector : edgeIntersectors)
+                                {
+                                    if (edgeIntersector.intersects(vertex))
+                                        n_intersections++;
+                                }
+                                if (n_intersections % 2 == (invert_selection ? 0 : 1))
+                                    intersectedIndices.push_back(i);
+                            }
+                        }
+
+                        if (!intersectedIndices.empty())
+                            add(localToWorld, intersectedIndices, inst);
+                    }
+                };
+
+                switch (arrayState.vertexAttribute.format)
+                {
+                case VK_FORMAT_R8G8B8_UNORM: {
+                    auto src_vertices = arrayState.arrays[arrayState.vertexAttribute.binding].cast<vsg::ubvec3Array>();
+                    processVertices(src_vertices, [](const vsg::ubvec3& sv) {
+                        return vsg::dvec3(static_cast<double>(sv.x), static_cast<double>(sv.y), static_cast<double>(sv.z));
+                    });
+                }
+                break;
+                case VK_FORMAT_A2R10G10B10_UNORM_PACK32: {
+                    auto src_vertices = arrayState.arrays[arrayState.vertexAttribute.binding].cast<vsg::uintArray>();
+                    processVertices(src_vertices, [](const uint32_t& sv) {
+                        return vsg::dvec3(static_cast<double>((sv >> 20) & 0x3FF), static_cast<double>((sv >> 10) & 0x3FF), static_cast<double>(sv & 0x3FF));
+                    });
+                }
+                break;
+                case VK_FORMAT_R16G16B16_UNORM: {
+                    auto src_vertices = arrayState.arrays[arrayState.vertexAttribute.binding].cast<vsg::usvec3Array>();
+                    processVertices(src_vertices, [](const vsg::usvec3& sv) {
+                        return vsg::dvec3(static_cast<double>(sv.x), static_cast<double>(sv.y), static_cast<double>(sv.z));
+                    });
+                }
+                break;
+                }
+                return;
+            }
+            else
+                return;
+        }
+    }
+
+    PushPopNode ppn(_nodePath, &vid);
+}


### PR DESCRIPTION
Adds a polytope intersector and a polygon intersector along with a point selection example.

`PointPolytopeIntersector` is a `vsg::PolytopeIntersector` subclass with an additional step which transforms the polytope into the scaled packed integer vertex coordinates that VSG::Points uses.

`PolygonIntersector` is for selecting points within a screenspace polygon. The polygon is divided into a series of "edges" using the near / far planes for each polygon point. The number of edge intersects from a ray from each point is counted to ascertain if the point is inside or outside the polygon.

There is a `pointselection` example which demonstrates and example usage of these intersectors. If no file name is supplied a default pointcloud is created with points that change from green to red when selected. If a file name is provided for an existing vsgPoints pointcloud, then intersection coordinates are output on the console:

Keys:

"1" - Square (PointPolytopeIntersector) intersector mode
"2" - Polygon (PolygonIntersector) mode. Starts drawing a polygon by clicking points on screen, pressing 2 again stops adding points
R Mouse:  Intersects
"r" - Resets point colours
"o" - Intersects points outside the polygon (polygon selection mode only).

Tested on windows. There is currently an issue if the window is resized as the overlay camera's (used to draw polygons on) ResizeHandler does not receive the latest window size following resizes. 


 